### PR TITLE
perf(allocator): optimize size_to_class to O(1)

### DIFF
--- a/kernel/src/allocator.rs
+++ b/kernel/src/allocator.rs
@@ -147,9 +147,19 @@ impl SlabAllocator {
         info!("Slab Allocator initialized successfully");
     }
 
-    // サイズからサイズクラスのインデックスを取得
+    // サイズからサイズクラスのインデックスを取得（O(1)）
     fn size_to_class(size: usize) -> Option<usize> {
-        SIZE_CLASSES.iter().position(|&s| s >= size)
+        if size == 0 {
+            return Some(0);
+        }
+        if size > 4096 {
+            return None;
+        }
+        // 2のべき乗に切り上げてインデックスを計算
+        // 8=2^3がインデックス0なので、ビット位置から3を引く
+        let bits = usize::BITS - (size - 1).leading_zeros();
+        let class_idx = bits.saturating_sub(3) as usize;
+        Some(class_idx)
     }
 
     // 大きなサイズ用のアロケート（バンプアロケータ）


### PR DESCRIPTION
## Summary

- `size_to_class`関数を線形探索（O(10)）からビット演算（O(1)）に最適化
- `leading_zeros()`を使用して2のべき乗に切り上げ、インデックスを計算
- `alloc()`/`dealloc()`の毎回の呼び出しで性能向上

## Test plan

- [x] `cargo build` でビルド確認
- [x] QEMU起動確認

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)