### PR TITLE
perf(allocator): O(1) bitmap-based free block lookup

### DIFF
--- a/kernel/src/allocator.rs
+++ b/kernel/src/allocator.rs
@@ -31,9 +31,9 @@ const MIN_BLOCK_SIZE_LOG2: u32 = 12;
 const MAX_ORDER: usize = 13;
 
 /// ビットマップの最大ワード数
-/// 64MB / 4KB / 64 = 256ワード
-/// 実際のヒープサイズ（最大64MB）に対応
-const MAX_BITMAP_WORDS: usize = 256;
+/// 1GB / 4KB / 64 = 4096ワード
+/// 実際のヒープサイズ（約1GB）に対応
+const MAX_BITMAP_WORDS: usize = 4096;
 
 /// フリーブロックノード（双方向リンクリスト）
 #[repr(C)]


### PR DESCRIPTION
## Summary

- `deallocate`時のバディ結合判定をO(n)線形探索からO(1)ビットマップ判定に改善
- 各オーダーごとにフリーブロックの状態をビットマップで追跡
- テスト用`init_test_heap`の二重初期化問題を修正
- ビットマップ関連のユニットテスト5件を追加
- ビットマップ操作に`# Safety`ドキュメントと`debug_assert!`境界チェックを追加

## Test plan

- [x] `cargo +nightly test -p vitros-kernel --target x86_64-unknown-none` (40テスト全パス)
- [x] `cargo +nightly run` でQEMU起動確認

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)