### PR TITLE
feat(memory): add PMM and dynamic MMIO page tables

### DIFF
--- a/kernel/src/frame_allocator.rs
+++ b/kernel/src/frame_allocator.rs
@@ -1,0 +1,651 @@
+//! 物理メモリアロケータ（4KBページフレーム管理）
+//!
+//! UEFIメモリマップから `EFI_CONVENTIONAL_MEMORY` 領域を取り込み、
+//! 4KBフレーム単位で割り当て/解放を行う。
+
+use crate::info;
+use crate::io::without_interrupts;
+use core::fmt;
+use vitros_common::boot_info::{BootInfo, MAX_MEMORY_REGIONS, MemoryRegion};
+use vitros_common::uefi::EFI_CONVENTIONAL_MEMORY;
+
+const PAGE_SIZE: u64 = 4096;
+const MAX_FREE_RANGES: usize = MAX_MEMORY_REGIONS * 4;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FrameAllocError {
+    NotInitialized,
+    AlreadyInitialized,
+    InvalidAddress,
+    InvalidRange,
+    OutOfMemory,
+    OutOfMemoryBelowLimit,
+    AddressNotManaged,
+    DoubleFree,
+    TooManyRanges,
+    NoUsableMemory,
+}
+
+impl fmt::Display for FrameAllocError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FrameAllocError::NotInitialized => write!(f, "Frame allocator is not initialized"),
+            FrameAllocError::AlreadyInitialized => {
+                write!(f, "Frame allocator is already initialized")
+            }
+            FrameAllocError::InvalidAddress => write!(f, "Invalid physical address"),
+            FrameAllocError::InvalidRange => write!(f, "Invalid range"),
+            FrameAllocError::OutOfMemory => write!(f, "Out of physical memory"),
+            FrameAllocError::OutOfMemoryBelowLimit => {
+                write!(f, "Out of physical memory below limit")
+            }
+            FrameAllocError::AddressNotManaged => write!(f, "Address is outside managed ranges"),
+            FrameAllocError::DoubleFree => write!(f, "Double free detected"),
+            FrameAllocError::TooManyRanges => write!(f, "Too many free ranges"),
+            FrameAllocError::NoUsableMemory => write!(f, "No usable memory regions found"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(C)]
+struct PhysRange {
+    start: u64,
+    end: u64,
+}
+
+impl PhysRange {
+    const fn empty() -> Self {
+        Self { start: 0, end: 0 }
+    }
+
+    #[inline]
+    fn is_valid(&self) -> bool {
+        self.start < self.end
+    }
+
+    #[inline]
+    fn page_count(&self) -> usize {
+        ((self.end - self.start) / PAGE_SIZE) as usize
+    }
+}
+
+#[derive(Clone, Copy)]
+struct FrameAllocator {
+    initialized: bool,
+    free_ranges: [PhysRange; MAX_FREE_RANGES],
+    free_count: usize,
+    managed_ranges: [PhysRange; MAX_MEMORY_REGIONS],
+    managed_count: usize,
+    total_pages: usize,
+    free_pages: usize,
+}
+
+impl FrameAllocator {
+    const fn new() -> Self {
+        Self {
+            initialized: false,
+            free_ranges: [PhysRange::empty(); MAX_FREE_RANGES],
+            free_count: 0,
+            managed_ranges: [PhysRange::empty(); MAX_MEMORY_REGIONS],
+            managed_count: 0,
+            total_pages: 0,
+            free_pages: 0,
+        }
+    }
+
+    fn reset(&mut self) {
+        self.initialized = false;
+        self.free_count = 0;
+        self.managed_count = 0;
+        self.total_pages = 0;
+        self.free_pages = 0;
+
+        for range in &mut self.free_ranges {
+            *range = PhysRange::empty();
+        }
+        for range in &mut self.managed_ranges {
+            *range = PhysRange::empty();
+        }
+    }
+
+    fn init(&mut self, boot_info: &BootInfo) -> Result<(), FrameAllocError> {
+        if self.initialized {
+            return Err(FrameAllocError::AlreadyInitialized);
+        }
+
+        self.reset();
+
+        let count = boot_info.memory_map_count.min(boot_info.memory_map.len());
+        let mut raw_ranges = [PhysRange::empty(); MAX_MEMORY_REGIONS];
+        let mut raw_count = 0usize;
+
+        for region in &boot_info.memory_map[..count] {
+            if region.region_type != EFI_CONVENTIONAL_MEMORY {
+                continue;
+            }
+
+            if let Some(range) = align_region_to_pages(region)
+                && raw_count < raw_ranges.len()
+            {
+                raw_ranges[raw_count] = range;
+                raw_count += 1;
+            }
+        }
+
+        if raw_count == 0 {
+            return Err(FrameAllocError::NoUsableMemory);
+        }
+
+        sort_ranges(&mut raw_ranges, raw_count);
+        let merged_count = merge_ranges(&mut raw_ranges, raw_count);
+
+        if merged_count > self.managed_ranges.len() {
+            return Err(FrameAllocError::TooManyRanges);
+        }
+
+        self.managed_ranges[..merged_count].copy_from_slice(&raw_ranges[..merged_count]);
+        self.managed_count = merged_count;
+
+        if merged_count > self.free_ranges.len() {
+            return Err(FrameAllocError::TooManyRanges);
+        }
+
+        self.free_ranges[..merged_count].copy_from_slice(&raw_ranges[..merged_count]);
+        self.free_count = merged_count;
+
+        self.total_pages = count_pages(&self.managed_ranges, self.managed_count);
+        self.free_pages = count_pages(&self.free_ranges, self.free_count);
+
+        self.initialized = true;
+
+        info!(
+            "Frame allocator initialized: {} ranges, {} total pages ({} MiB)",
+            self.managed_count,
+            self.total_pages,
+            (self.total_pages as u64 * PAGE_SIZE) / (1024 * 1024)
+        );
+        info!(
+            "Frame allocator free: {} ranges, {} pages",
+            self.free_count, self.free_pages
+        );
+
+        Ok(())
+    }
+
+    fn alloc_frame_below(&mut self, limit_exclusive: u64) -> Result<u64, FrameAllocError> {
+        if !self.initialized {
+            return Err(FrameAllocError::NotInitialized);
+        }
+
+        let limit = align_down(limit_exclusive, PAGE_SIZE);
+        if limit < PAGE_SIZE {
+            return Err(FrameAllocError::OutOfMemoryBelowLimit);
+        }
+
+        for i in 0..self.free_count {
+            let range = self.free_ranges[i];
+            if range.start >= limit {
+                break;
+            }
+
+            let alloc_start = range.start;
+            let alloc_end = alloc_start + PAGE_SIZE;
+
+            if alloc_end > range.end || alloc_end > limit {
+                continue;
+            }
+
+            self.free_ranges[i].start = alloc_end;
+            if self.free_ranges[i].start == self.free_ranges[i].end {
+                remove_range(&mut self.free_ranges, &mut self.free_count, i);
+            }
+
+            self.free_pages = self.free_pages.saturating_sub(1);
+            return Ok(alloc_start);
+        }
+
+        Err(FrameAllocError::OutOfMemoryBelowLimit)
+    }
+
+    fn free_frame(&mut self, frame_phys: u64) -> Result<(), FrameAllocError> {
+        if !self.initialized {
+            return Err(FrameAllocError::NotInitialized);
+        }
+        if frame_phys & (PAGE_SIZE - 1) != 0 {
+            return Err(FrameAllocError::InvalidAddress);
+        }
+
+        let frame_end = frame_phys
+            .checked_add(PAGE_SIZE)
+            .ok_or(FrameAllocError::InvalidAddress)?;
+
+        if !self.is_managed_frame(frame_phys) {
+            return Err(FrameAllocError::AddressNotManaged);
+        }
+
+        for i in 0..self.free_count {
+            let range = self.free_ranges[i];
+            if frame_phys < range.end && frame_end > range.start {
+                return Err(FrameAllocError::DoubleFree);
+            }
+        }
+
+        if self.free_count >= self.free_ranges.len() {
+            return Err(FrameAllocError::TooManyRanges);
+        }
+
+        let mut insert_idx = self.free_count;
+        for i in 0..self.free_count {
+            if frame_phys < self.free_ranges[i].start {
+                insert_idx = i;
+                break;
+            }
+        }
+
+        insert_range(
+            &mut self.free_ranges,
+            &mut self.free_count,
+            insert_idx,
+            PhysRange {
+                start: frame_phys,
+                end: frame_end,
+            },
+        )?;
+
+        self.free_pages += 1;
+        self.merge_neighbors(insert_idx);
+
+        Ok(())
+    }
+
+    fn reserve_range(&mut self, start: u64, size: u64) -> Result<(), FrameAllocError> {
+        if !self.initialized {
+            return Err(FrameAllocError::NotInitialized);
+        }
+        if size == 0 {
+            return Ok(());
+        }
+
+        let end = start
+            .checked_add(size)
+            .ok_or(FrameAllocError::InvalidRange)?;
+        let reserve_start = align_down(start, PAGE_SIZE);
+        let reserve_end = align_up(end, PAGE_SIZE).ok_or(FrameAllocError::InvalidRange)?;
+
+        if reserve_start >= reserve_end {
+            return Ok(());
+        }
+
+        let mut new_ranges = [PhysRange::empty(); MAX_FREE_RANGES];
+        let mut new_count = 0usize;
+
+        for i in 0..self.free_count {
+            let range = self.free_ranges[i];
+            if range.end <= reserve_start || range.start >= reserve_end {
+                if new_count >= new_ranges.len() {
+                    return Err(FrameAllocError::TooManyRanges);
+                }
+                new_ranges[new_count] = range;
+                new_count += 1;
+                continue;
+            }
+
+            if range.start < reserve_start {
+                if new_count >= new_ranges.len() {
+                    return Err(FrameAllocError::TooManyRanges);
+                }
+                new_ranges[new_count] = PhysRange {
+                    start: range.start,
+                    end: reserve_start,
+                };
+                new_count += 1;
+            }
+
+            if reserve_end < range.end {
+                if new_count >= new_ranges.len() {
+                    return Err(FrameAllocError::TooManyRanges);
+                }
+                new_ranges[new_count] = PhysRange {
+                    start: reserve_end,
+                    end: range.end,
+                };
+                new_count += 1;
+            }
+        }
+
+        self.free_ranges[..new_count].copy_from_slice(&new_ranges[..new_count]);
+        for i in new_count..self.free_ranges.len() {
+            self.free_ranges[i] = PhysRange::empty();
+        }
+        self.free_count = new_count;
+        self.free_pages = count_pages(&self.free_ranges, self.free_count);
+
+        Ok(())
+    }
+
+    fn is_managed_frame(&self, frame_phys: u64) -> bool {
+        let frame_end = frame_phys + PAGE_SIZE;
+        for i in 0..self.managed_count {
+            let range = self.managed_ranges[i];
+            if frame_phys >= range.start && frame_end <= range.end {
+                return true;
+            }
+            if frame_phys < range.start {
+                break;
+            }
+        }
+        false
+    }
+
+    fn merge_neighbors(&mut self, mut idx: usize) {
+        if self.free_count == 0 {
+            return;
+        }
+
+        if idx > 0 {
+            let prev = self.free_ranges[idx - 1];
+            let curr = self.free_ranges[idx];
+            if prev.end == curr.start {
+                self.free_ranges[idx - 1].end = curr.end;
+                remove_range(&mut self.free_ranges, &mut self.free_count, idx);
+                idx -= 1;
+            }
+        }
+
+        if idx + 1 < self.free_count {
+            let curr = self.free_ranges[idx];
+            let next = self.free_ranges[idx + 1];
+            if curr.end == next.start {
+                self.free_ranges[idx].end = next.end;
+                remove_range(&mut self.free_ranges, &mut self.free_count, idx + 1);
+            }
+        }
+    }
+}
+
+static mut FRAME_ALLOCATOR: FrameAllocator = FrameAllocator::new();
+
+pub fn init(boot_info: &BootInfo) -> Result<(), FrameAllocError> {
+    without_interrupts(|| unsafe {
+        let allocator = core::ptr::addr_of_mut!(FRAME_ALLOCATOR);
+        (*allocator).init(boot_info)
+    })
+}
+
+pub fn alloc_frame_below(limit_exclusive: u64) -> Result<u64, FrameAllocError> {
+    without_interrupts(|| unsafe {
+        let allocator = core::ptr::addr_of_mut!(FRAME_ALLOCATOR);
+        (*allocator).alloc_frame_below(limit_exclusive)
+    })
+}
+
+pub fn free_frame(frame_phys: u64) -> Result<(), FrameAllocError> {
+    without_interrupts(|| unsafe {
+        let allocator = core::ptr::addr_of_mut!(FRAME_ALLOCATOR);
+        (*allocator).free_frame(frame_phys)
+    })
+}
+
+pub fn reserve_range(start: u64, size: u64) -> Result<(), FrameAllocError> {
+    without_interrupts(|| unsafe {
+        let allocator = core::ptr::addr_of_mut!(FRAME_ALLOCATOR);
+        (*allocator).reserve_range(start, size)
+    })
+}
+
+#[cfg(test)]
+pub(crate) fn reset_for_test() {
+    without_interrupts(|| unsafe {
+        let allocator = core::ptr::addr_of_mut!(FRAME_ALLOCATOR);
+        (*allocator).reset();
+    });
+}
+
+#[cfg(test)]
+pub(crate) fn debug_free_pages() -> usize {
+    without_interrupts(|| unsafe {
+        let allocator = core::ptr::addr_of!(FRAME_ALLOCATOR);
+        (*allocator).free_pages
+    })
+}
+
+#[cfg(test)]
+pub(crate) fn debug_free_count() -> usize {
+    without_interrupts(|| unsafe {
+        let allocator = core::ptr::addr_of!(FRAME_ALLOCATOR);
+        (*allocator).free_count
+    })
+}
+
+#[inline]
+fn count_pages(ranges: &[PhysRange], count: usize) -> usize {
+    let mut pages = 0usize;
+    for range in ranges.iter().take(count) {
+        pages += range.page_count();
+    }
+    pages
+}
+
+fn align_region_to_pages(region: &MemoryRegion) -> Option<PhysRange> {
+    if region.size == 0 {
+        return None;
+    }
+
+    let end = region.start.checked_add(region.size)?;
+    let start_aligned = align_up(region.start, PAGE_SIZE)?;
+    let end_aligned = align_down(end, PAGE_SIZE);
+
+    if start_aligned >= end_aligned {
+        return None;
+    }
+
+    Some(PhysRange {
+        start: start_aligned,
+        end: end_aligned,
+    })
+}
+
+fn sort_ranges(ranges: &mut [PhysRange], count: usize) {
+    for i in 1..count {
+        let key = ranges[i];
+        let mut j = i;
+        while j > 0 && ranges[j - 1].start > key.start {
+            ranges[j] = ranges[j - 1];
+            j -= 1;
+        }
+        ranges[j] = key;
+    }
+}
+
+fn merge_ranges(ranges: &mut [PhysRange], count: usize) -> usize {
+    if count == 0 {
+        return 0;
+    }
+
+    let mut write_idx = 0usize;
+    for i in 1..count {
+        let curr = ranges[i];
+        let write = &mut ranges[write_idx];
+        if curr.start <= write.end {
+            write.end = write.end.max(curr.end);
+        } else {
+            write_idx += 1;
+            ranges[write_idx] = curr;
+        }
+    }
+
+    write_idx + 1
+}
+
+fn insert_range(
+    ranges: &mut [PhysRange; MAX_FREE_RANGES],
+    count: &mut usize,
+    idx: usize,
+    range: PhysRange,
+) -> Result<(), FrameAllocError> {
+    if !range.is_valid() {
+        return Err(FrameAllocError::InvalidRange);
+    }
+    if *count >= ranges.len() || idx > *count {
+        return Err(FrameAllocError::TooManyRanges);
+    }
+
+    for i in (idx..*count).rev() {
+        ranges[i + 1] = ranges[i];
+    }
+    ranges[idx] = range;
+    *count += 1;
+    Ok(())
+}
+
+fn remove_range(ranges: &mut [PhysRange; MAX_FREE_RANGES], count: &mut usize, idx: usize) {
+    if idx >= *count {
+        return;
+    }
+    for i in idx..(*count - 1) {
+        ranges[i] = ranges[i + 1];
+    }
+    *count -= 1;
+    ranges[*count] = PhysRange::empty();
+}
+
+#[inline]
+fn align_down(value: u64, align: u64) -> u64 {
+    value & !(align - 1)
+}
+
+#[inline]
+fn align_up(value: u64, align: u64) -> Option<u64> {
+    let addend = align - 1;
+    value.checked_add(addend).map(|v| v & !addend)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vitros_common::boot_info::{BootInfo, MemoryRegion};
+
+    fn boot_info_with_regions(regions: &[MemoryRegion]) -> BootInfo {
+        let mut boot_info = BootInfo::new();
+        for (i, region) in regions.iter().enumerate() {
+            boot_info.memory_map[i] = *region;
+        }
+        boot_info.memory_map_count = regions.len();
+        boot_info
+    }
+
+    #[test_case]
+    fn test_init_conventional_only() {
+        reset_for_test();
+        let boot_info = boot_info_with_regions(&[
+            MemoryRegion {
+                start: 0x1000,
+                size: 0x9000,
+                region_type: vitros_common::uefi::EFI_BOOT_SERVICES_CODE,
+            },
+            MemoryRegion {
+                start: 0x20000,
+                size: 0x4000,
+                region_type: EFI_CONVENTIONAL_MEMORY,
+            },
+        ]);
+
+        init(&boot_info).expect("init failed");
+        assert_eq!(debug_free_pages(), 4);
+        assert_eq!(debug_free_count(), 1);
+    }
+
+    #[test_case]
+    fn test_alloc_and_free_frame() {
+        reset_for_test();
+        let boot_info = boot_info_with_regions(&[MemoryRegion {
+            start: 0x400000,
+            size: 0x5000,
+            region_type: EFI_CONVENTIONAL_MEMORY,
+        }]);
+        init(&boot_info).expect("init failed");
+
+        let a = alloc_frame_below(0x800000).expect("alloc a failed");
+        let b = alloc_frame_below(0x800000).expect("alloc b failed");
+        assert_eq!(a, 0x400000);
+        assert_eq!(b, 0x401000);
+
+        free_frame(a).expect("free failed");
+        let c = alloc_frame_below(0x800000).expect("alloc c failed");
+        assert_eq!(c, a);
+    }
+
+    #[test_case]
+    fn test_reserve_range_split() {
+        reset_for_test();
+        let boot_info = boot_info_with_regions(&[MemoryRegion {
+            start: 0x100000,
+            size: 0x10000,
+            region_type: EFI_CONVENTIONAL_MEMORY,
+        }]);
+        init(&boot_info).expect("init failed");
+
+        reserve_range(0x103000, 0x4000).expect("reserve failed");
+        assert_eq!(debug_free_count(), 2);
+        assert_eq!(debug_free_pages(), 12);
+    }
+
+    #[test_case]
+    fn test_alloc_frame_below_limit() {
+        reset_for_test();
+        let boot_info = boot_info_with_regions(&[
+            MemoryRegion {
+                start: 0x100000,
+                size: 0x4000,
+                region_type: EFI_CONVENTIONAL_MEMORY,
+            },
+            MemoryRegion {
+                start: 0x200000,
+                size: 0x4000,
+                region_type: EFI_CONVENTIONAL_MEMORY,
+            },
+        ]);
+        init(&boot_info).expect("init failed");
+
+        let f = alloc_frame_below(0x180000).expect("alloc below failed");
+        assert!(f < 0x180000);
+
+        let e = alloc_frame_below(0x100000);
+        assert_eq!(e, Err(FrameAllocError::OutOfMemoryBelowLimit));
+    }
+
+    #[test_case]
+    fn test_free_frame_errors() {
+        reset_for_test();
+        let boot_info = boot_info_with_regions(&[MemoryRegion {
+            start: 0x300000,
+            size: 0x2000,
+            region_type: EFI_CONVENTIONAL_MEMORY,
+        }]);
+        init(&boot_info).expect("init failed");
+
+        assert_eq!(free_frame(0x1234), Err(FrameAllocError::InvalidAddress));
+
+        let frame = alloc_frame_below(0x400000).expect("alloc failed");
+        free_frame(frame).expect("free once failed");
+        assert_eq!(free_frame(frame), Err(FrameAllocError::DoubleFree));
+
+        assert_eq!(
+            free_frame(0x900000),
+            Err(FrameAllocError::AddressNotManaged)
+        );
+    }
+
+    #[test_case]
+    fn test_init_no_usable_memory() {
+        reset_for_test();
+        let boot_info = boot_info_with_regions(&[MemoryRegion {
+            start: 0x1000,
+            size: 0x2000,
+            region_type: vitros_common::uefi::EFI_ACPI_RECLAIM_MEMORY,
+        }]);
+
+        assert_eq!(init(&boot_info), Err(FrameAllocError::NoUsableMemory));
+    }
+}

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -16,6 +16,7 @@ pub mod addr;
 pub mod allocator;
 pub mod apic;
 pub mod debug_overlay;
+pub mod frame_allocator;
 pub mod gdt;
 pub mod graphics;
 pub mod hpet;

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -11,6 +11,7 @@ use vitros_kernel::acpi;
 use vitros_kernel::allocator;
 use vitros_kernel::apic;
 use vitros_kernel::debug_overlay;
+use vitros_kernel::frame_allocator;
 use vitros_kernel::gdt;
 use vitros_kernel::graphics;
 use vitros_kernel::idt;
@@ -205,6 +206,23 @@ extern "C" fn kernel_main_inner(boot_info_phys_addr: u64) -> ! {
     // カーネル実行中は不変であることが保証されている。
     let boot_info = unsafe { &*(boot_info_virt_addr as *const BootInfo) };
 
+    // ヒープ候補となる最大のConventional Memory領域を先に決定
+    let safe_count = boot_info.memory_map_count.min(boot_info.memory_map.len());
+    let mut largest_start_phys: u64 = 0;
+    let mut largest_size: usize = 0;
+    for i in 0..safe_count {
+        let region = &boot_info.memory_map[i];
+        if region.region_type == uefi::EFI_CONVENTIONAL_MEMORY && region.size > largest_size as u64
+        {
+            largest_start_phys = region.start;
+            largest_size = region.size as usize;
+        }
+    }
+    #[cfg(feature = "visualize-allocator")]
+    let heap_size = largest_size.min(256 * 1024); // 可視化のため256KBに制限
+    #[cfg(not(feature = "visualize-allocator"))]
+    let heap_size = largest_size; // 本番環境では全て使用
+
     // GDTを初期化
     info!("Initializing GDT...");
     gdt::init().expect("Failed to initialize GDT");
@@ -218,6 +236,19 @@ extern "C" fn kernel_main_inner(boot_info_phys_addr: u64) -> ! {
     info!("Creating kernel page tables...");
     paging::init(boot_info).expect("Failed to initialize paging system");
     info!("Kernel page tables created and loaded");
+
+    // 物理メモリアロケータを初期化
+    info!("Initializing frame allocator...");
+    frame_allocator::init(boot_info).expect("Failed to initialize frame allocator");
+    if heap_size > 0 {
+        frame_allocator::reserve_range(largest_start_phys, heap_size as u64)
+            .expect("Failed to reserve heap range in frame allocator");
+        info!(
+            "Reserved heap range in frame allocator: phys=0x{:X}, size={} KB",
+            largest_start_phys,
+            heap_size / 1024
+        );
+    }
 
     // GDTを高位アドレスで再ロード（念のため）
     info!("Reloading GDT...");
@@ -287,34 +318,10 @@ extern "C" fn kernel_main_inner(boot_info_phys_addr: u64) -> ! {
 
     info!("Memory map count: {}", boot_info.memory_map_count);
     info!("Memory map array len: {}", boot_info.memory_map.len());
-
-    // 利用可能なメモリを探してアロケータを初期化
-    let mut largest_start_phys: u64 = 0;
-    let mut largest_size = 0;
-
-    // 配列の範囲内に制限
-    let safe_count = boot_info.memory_map_count.min(boot_info.memory_map.len());
     info!("Using safe count: {}", safe_count);
-
-    for i in 0..safe_count {
-        let region = &boot_info.memory_map[i];
-        // region_type == 7 は EFI_CONVENTIONAL_MEMORY
-        if region.region_type == uefi::EFI_CONVENTIONAL_MEMORY && region.size > largest_size as u64
-        {
-            largest_start_phys = region.start;
-            largest_size = region.size as usize;
-        }
-    }
 
     if largest_size > 0 {
         info!("Found usable memory");
-
-        // ヒープサイズを決定
-        #[cfg(feature = "visualize-allocator")]
-        let heap_size = largest_size.min(256 * 1024); // 可視化のため256KBに制限
-
-        #[cfg(not(feature = "visualize-allocator"))]
-        let heap_size = largest_size; // 本番環境では全て使用
 
         // 物理アドレスを高位仮想アドレスに変換
         let largest_start_virt =

--- a/kernel/src/paging.rs
+++ b/kernel/src/paging.rs
@@ -39,6 +39,8 @@ pub enum PagingError {
     FeatureNotSupported,
     /// 既存のマッピングと競合（PT/PD参照が既に存在）
     ExistingMappingConflict,
+    /// ページテーブル用フレームの確保に失敗
+    FrameAllocationFailed,
 }
 
 impl core::fmt::Display for PagingError {
@@ -53,6 +55,7 @@ impl core::fmt::Display for PagingError {
             PagingError::ExistingMappingConflict => {
                 write!(f, "Existing page table mapping conflict")
             }
+            PagingError::FrameAllocationFailed => write!(f, "Page-table frame allocation failed"),
         }
     }
 }
@@ -386,6 +389,9 @@ static mut KERNEL_PD_HIGH: [PageTable; MAX_SUPPORTED_MEMORY_GB] =
 // 低位アドレスはアンマップ（ハイヤーハーフカーネル）
 static mut KERNEL_PT_HIGH: [PageTable; PT_COUNT] = [PageTable::new(); PT_COUNT];
 
+// map_mmio() がページテーブル拡張に使えるフレームの上限（初期直写済み範囲）
+static mut INITIAL_MAPPED_MAX_PHYS: u64 = 0;
+
 /// ページングシステムを初期化してCR3に設定
 /// 物理メモリの直接マッピング（Direct Mapping）を実装
 /// - 低位アドレス（0x0〜）: アンマップ（ハイヤーハーフカーネル）
@@ -404,6 +410,10 @@ pub fn init(boot_info: &vitros_common::boot_info::BootInfo) -> Result<(), Paging
     // サポートする最大アドレスを計算
     let max_supported = (MAX_SUPPORTED_MEMORY_GB as u64) << 30; // 8GB
     let actual_max = boot_info.max_physical_address.min(max_supported);
+
+    unsafe {
+        INITIAL_MAPPED_MAX_PHYS = actual_max;
+    }
 
     // 必要なPD数とPT数を計算
     // 1 PT = 512 * 4KB = 2MB
@@ -641,6 +651,46 @@ fn assert_interrupts_disabled(context: &str) {
     );
 }
 
+#[inline]
+fn direct_map_table_indices(phys_addr: u64) -> Result<(usize, usize, usize, usize), PagingError> {
+    let virt_addr = phys_to_virt(phys_addr)?;
+    let pml4_idx = ((virt_addr >> 39) & 0x1FF) as usize;
+    let pdp_idx = ((virt_addr >> 30) & 0x1FF) as usize;
+    let pd_idx = ((virt_addr >> 21) & 0x1FF) as usize;
+    let pt_idx = ((virt_addr >> 12) & 0x1FF) as usize;
+    Ok((pml4_idx, pdp_idx, pd_idx, pt_idx))
+}
+
+unsafe fn table_from_entry(entry: &PageTableEntry) -> Result<*mut PageTable, PagingError> {
+    if !entry.is_present() {
+        return Err(PagingError::PageTableInitFailed);
+    }
+    if entry.is_huge_page() {
+        return Err(PagingError::ExistingMappingConflict);
+    }
+    let table_phys = entry.get_address();
+    let table_virt = phys_to_virt(table_phys)?;
+    Ok(table_virt as *mut PageTable)
+}
+
+unsafe fn alloc_page_table_frame() -> Result<*mut PageTable, PagingError> {
+    let limit = unsafe { INITIAL_MAPPED_MAX_PHYS };
+    if limit < PAGE_SIZE as u64 {
+        return Err(PagingError::FrameAllocationFailed);
+    }
+
+    let frame_phys = crate::frame_allocator::alloc_frame_below(limit)
+        .map_err(|_| PagingError::FrameAllocationFailed)?;
+    let frame_virt = phys_to_virt(frame_phys)?;
+    let frame_ptr = frame_virt as *mut PageTable;
+
+    unsafe {
+        (*frame_ptr).clear();
+    }
+
+    Ok(frame_ptr)
+}
+
 /// MMIO領域をUC（Uncacheable）属性でマッピングする
 ///
 /// init()でスキップされたMMIO領域を、デバイス使用前に動的にマッピングする。
@@ -665,7 +715,9 @@ fn assert_interrupts_disabled(context: &str) {
 ///
 /// # Errors
 /// * `PagingError::InvalidAddress` - アドレスが4KB境界にアライメントされていない場合
-/// * `PagingError::PageTableInitFailed` - ページテーブルのインデックスが範囲外の場合
+/// * `PagingError::AddressOutOfRange` - 直接マップ可能範囲外の物理アドレスの場合
+/// * `PagingError::ExistingMappingConflict` - 既存HugePageマッピングと衝突した場合
+/// * `PagingError::FrameAllocationFailed` - ページテーブル用フレーム確保に失敗した場合
 pub fn map_mmio(phys_addr: u64, size: u64) -> Result<u64, PagingError> {
     use crate::info;
 
@@ -684,32 +736,67 @@ pub fn map_mmio(phys_addr: u64, size: u64) -> Result<u64, PagingError> {
     let uc_flags = PageTableFlags::Present as u64
         | PageTableFlags::Writable as u64
         | PageTableFlags::CacheDisable as u64;
+    let table_flags = PageTableFlags::Present as u64 | PageTableFlags::Writable as u64;
 
     unsafe {
-        let pt_high = addr_of_mut!(KERNEL_PT_HIGH);
+        let pml4 = addr_of_mut!(KERNEL_PML4);
 
         for i in 0..page_count {
             let addr = phys_addr + (i * PAGE_SIZE) as u64;
+            let (pml4_idx, pdp_idx, pd_idx, pt_idx) = direct_map_table_indices(addr)?;
+            if pml4_idx != PML4_KERNEL_INDEX {
+                return Err(PagingError::AddressOutOfRange);
+            }
 
-            // ページ番号を計算
-            let page_num = (addr >> 12) as usize;
-
-            // PT配列内のインデックスとPT内のエントリ番号を計算
-            let pt_array_idx = page_num / PAGE_TABLE_ENTRY_COUNT;
-            let page_idx_in_pt = page_num % PAGE_TABLE_ENTRY_COUNT;
-
-            // インデックスの範囲検証
-            if pt_array_idx >= PT_COUNT {
+            // PML4 -> PDP は init() で固定設定済み
+            let pdp_entry = (*pml4).entry(pml4_idx);
+            if !pdp_entry.is_present() {
                 return Err(PagingError::PageTableInitFailed);
             }
+            let pdp = table_from_entry(pdp_entry)?;
+
+            // PDP[pdp_idx] -> PD を必要時に動的確保
+            let pdp_entry = (*pdp).entry(pdp_idx);
+            let pd = if pdp_entry.is_present() {
+                if pdp_entry.is_huge_page() {
+                    return Err(PagingError::ExistingMappingConflict);
+                }
+                table_from_entry(pdp_entry)?
+            } else {
+                let new_pd = alloc_page_table_frame()?;
+                let new_pd_phys = virt_to_phys(new_pd as u64)?;
+                pdp_entry.set(new_pd_phys, table_flags);
+                #[cfg(debug_assertions)]
+                info!(
+                    "map_mmio: allocated PD table phys=0x{:X} for PDP index {}",
+                    new_pd_phys, pdp_idx
+                );
+                new_pd
+            };
+
+            // PD[pd_idx] -> PT を必要時に動的確保
+            let pd_entry = (*pd).entry(pd_idx);
+            let pt = if pd_entry.is_present() {
+                if pd_entry.is_huge_page() {
+                    return Err(PagingError::ExistingMappingConflict);
+                }
+                table_from_entry(pd_entry)?
+            } else {
+                let new_pt = alloc_page_table_frame()?;
+                let new_pt_phys = virt_to_phys(new_pt as u64)?;
+                pd_entry.set(new_pt_phys, table_flags);
+                #[cfg(debug_assertions)]
+                info!(
+                    "map_mmio: allocated PT table phys=0x{:X} for PD index {}",
+                    new_pt_phys, pd_idx
+                );
+                new_pt
+            };
 
             // デバッグビルド時のみ重複マッピングを警告
             #[cfg(debug_assertions)]
             {
-                if (*pt_high)[pt_array_idx]
-                    .get_entry(page_idx_in_pt)
-                    .is_present()
-                {
+                if (*pt).get_entry(pt_idx).is_present() {
                     info!(
                         "Warning: map_mmio overwriting existing mapping at 0x{:X}",
                         addr
@@ -718,9 +805,7 @@ pub fn map_mmio(phys_addr: u64, size: u64) -> Result<u64, PagingError> {
             }
 
             // UC属性でページテーブルエントリを設定
-            (*pt_high)[pt_array_idx]
-                .entry(page_idx_in_pt)
-                .set(addr, uc_flags);
+            (*pt).entry(pt_idx).set(addr, uc_flags);
         }
 
         // TLBフラッシュ


### PR DESCRIPTION
## Summary
- add physical frame allocator (PMM) backed by UEFI conventional memory ranges
- initialize frame allocator at boot and reserve heap physical range
- refactor paging map_mmio to walk page tables and allocate missing PD/PT dynamically
- add PagingError::FrameAllocationFailed

## Why
- remove static PT index dependency that blocked high MMIO BAR mappings
- unblock xHCI MMIO mapping for Issue #48

## Validation
- cargo +nightly check -p vitros-kernel --target x86_64-unknown-none
- cargo +nightly test -p vitros-kernel --target x86_64-unknown-none
- DISABLE_KVM=1 timeout -k 5 70 cargo run (verified dynamic PD/PT allocation and xHCI MMIO mapping)

Refs #48